### PR TITLE
Beta (β) Annealing

### DIFF
--- a/apex.py
+++ b/apex.py
@@ -164,6 +164,7 @@ def learn(env_f,
           target_network_update_freq=2500,
           prioritized_replay_alpha=0.6,
           prioritized_replay_beta0=0.4,
+          prioritized_replay_beta_annealing=False,
           prioritized_replay_eps=1e-6,
           number_of_prefetched_batches=16,
           number_of_prefetching_threads=4,
@@ -296,8 +297,12 @@ def learn(env_f,
     # Make Learner input pipeline
 
     num_training_steps = tf.get_variable('training_steps', shape=(), dtype=tf.int64)
-    prioritized_replay_beta = U.linear_schedule(
-            num_training_steps, max_timesteps, prioritized_replay_beta0, 1.0)
+
+    if prioritized_replay_beta_annealing:
+        prioritized_replay_beta = U.linear_schedule(
+                num_training_steps, max_timesteps, prioritized_replay_beta0, 1.0)
+    else:
+        prioritized_replay_beta = prioritized_replay_beta0
 
     def make_training_input():
         with tf.variable_scope("training_input_preprocessing"):

--- a/apex.py
+++ b/apex.py
@@ -297,7 +297,7 @@ def learn(env_f,
 
     num_training_steps = tf.get_variable('training_steps', shape=(), dtype=tf.int64)
     prioritized_replay_beta = U.linear_schedule(
-            num_training_steps, num_timesteps, prioritized_replay_beta0, 1.0)
+            num_training_steps, max_timesteps, prioritized_replay_beta0, 1.0)
 
     def make_training_input():
         with tf.variable_scope("training_input_preprocessing"):

--- a/gym_tensorflow/tf_env.py
+++ b/gym_tensorflow/tf_env.py
@@ -14,9 +14,10 @@ See the License for the specific language governing permissions and
 limitations under the License.
 '''
 
-import numpy as np
 import os
 
+import gym
+import numpy as np
 import tensorflow as tf
 
 gym_tensorflow_module = tf.load_op_library(os.path.join(os.path.dirname(__file__), 'gym_tensorflow.so'))

--- a/tf_util.py
+++ b/tf_util.py
@@ -602,6 +602,12 @@ def fancy_slice_2d(X, inds0, inds1):
     Xflat = tf.reshape(X, [-1])
     return tf.gather(Xflat, inds0 * ncols + inds1)
 
+def linear_schedule(t, schedule_timesteps, initial_p, final_p):
+    schedule = tf.linspace(initial_p, final_p, schedule_timesteps)
+    return tf.cond(t < schedule.shape[0],
+                   lambda: schedule[t],
+                   lambda: schedule[-1])
+
 # ================================================================
 # Scopes
 # ================================================================


### PR DESCRIPTION
In the original Prioritized Experience Replay paper [1], the beta parameter is linearly annealed from its initial value β0 to 1 (section 3.4 in the paper). The schedule is defined such that it would only reach 1 towards the end of learning.

This pull request adds beta annealing as an option (disabled by default) by changing `prioritized_replay_beta_annealing` to True. It will create a linear schedule for beta similar to the implementation in OpenAI Baselines, but modified to operate on tensors & variables (e.g. utilising `num_training_steps` variable for current timestep).

[1] Schaul et al. 2016, "Prioritized Experience Replay", [arXiv:1511.05952](https://arxiv.org/abs/1511.05952)